### PR TITLE
Fix qemu-host for BYT

### DIFF
--- a/hw/adsp/dsp/byt.c
+++ b/hw/adsp/dsp/byt.c
@@ -237,7 +237,7 @@ static struct adsp_reg_space byt_io[] = {
         .reg = adsp_byt_shim_map, .init = &adsp_byt_shim_init, .ops = &byt_shim_ops,
         .desc = {.base = ADSP_BYT_DSP_SHIM_BASE, .size = ADSP_BYT_SHIM_SIZE},},
     { .name = "mbox", .reg_count = ARRAY_SIZE(adsp_mbox_map),
-        .reg = adsp_mbox_map, .ops = &mbox_io_ops,
+        .reg = adsp_mbox_map, .init = &adsp_mbox_init, .ops = &mbox_io_ops,
         .desc = {.base = ADSP_BYT_DSP_MAILBOX_BASE, .size = ADSP_MAILBOX_SIZE},},
 };
 

--- a/hw/adsp/dsp/byt.h
+++ b/hw/adsp/dsp/byt.h
@@ -51,5 +51,6 @@ void adsp_byt_shim_msg(struct adsp_dev *adsp, struct qemu_io_msg *msg);
 void adsp_byt_irq_msg(struct adsp_dev *adsp, struct qemu_io_msg *msg);
 void byt_ext_timer_cb(void *opaque);
 extern const MemoryRegionOps byt_shim_ops;
+extern const MemoryRegionOps adsp_mbox_ops;
 
 #endif

--- a/hw/adsp/host/byt-shim.c
+++ b/hw/adsp/host/byt-shim.c
@@ -22,8 +22,13 @@
 #include "hw/audio/adsp-host.h"
 #include "hw/adsp/log.h"
 
+uint64_t adsp_shim_read(void *opaque, hwaddr addr,
+                        unsigned size);
+void adsp_shim_write(void *opaque, hwaddr addr,
+                     uint64_t val, unsigned size);
+
 /* driver reads from the SHIM */
-static uint64_t adsp_shim_read(void *opaque, hwaddr addr,
+uint64_t adsp_shim_read(void *opaque, hwaddr addr,
         unsigned size)
 {
     struct adsp_io_info *info = opaque;
@@ -46,7 +51,7 @@ static uint64_t adsp_shim_read(void *opaque, hwaddr addr,
 }
 
 /* driver writes to the SHIM */
-static void adsp_shim_write(void *opaque, hwaddr addr,
+void adsp_shim_write(void *opaque, hwaddr addr,
         uint64_t val, unsigned size)
 {
     struct adsp_io_info *info = opaque;

--- a/hw/adsp/host/byt.c
+++ b/hw/adsp/host/byt.c
@@ -22,6 +22,10 @@
 #include "hw/adsp/byt.h"
 #include "hw/adsp/log.h"
 
+extern const MemoryRegionOps adsp_byt_host_shim_ops;
+extern const MemoryRegionOps adsp_host_mbox_ops;
+extern const MemoryRegionOps byt_host_pci_ops;
+
 static struct adsp_mem_desc byt_mem[] = {
     {.name = "iram", .base = ADSP_BYT_HOST_IRAM_BASE,
         .size = ADSP_BYT_IRAM_SIZE},
@@ -31,13 +35,22 @@ static struct adsp_mem_desc byt_mem[] = {
 
 static struct adsp_reg_space byt_io[] = {
     { .name = "pci",
-        .desc = {.base = ADSP_BYT_PCI_BASE, .size = ADSP_PCI_SIZE},},
+        .desc = {.base = ADSP_BYT_PCI_BASE, .size = ADSP_PCI_SIZE},
+        .init = (void*)adsp_byt_init_pci,
+        .ops = &byt_host_pci_ops,
+    },
     { .name = "shim", .reg_count = ARRAY_SIZE(adsp_byt_shim_map),
         .reg = adsp_byt_shim_map,
-        .desc = {.base = ADSP_BYT_DSP_SHIM_BASE, .size = ADSP_BYT_SHIM_SIZE},},
+        .desc = {.base = ADSP_BYT_HOST_SHIM_BASE, .size = ADSP_BYT_SHIM_SIZE},
+        .init = (void*)adsp_byt_init_shim,
+        .ops = &adsp_byt_host_shim_ops,
+    },
     { .name = "mbox", .reg_count = ARRAY_SIZE(adsp_host_mbox_map),
         .reg = adsp_host_mbox_map,
-        .desc = {.base = ADSP_BYT_DSP_MAILBOX_BASE, .size = ADSP_MAILBOX_SIZE},},
+        .desc = {.base = ADSP_BYT_HOST_MAILBOX_BASE, .size = ADSP_MAILBOX_SIZE},
+        .init = (void*)adsp_host_init_mbox,
+        .ops = &adsp_host_mbox_ops,
+    }
 };
 
 static const struct adsp_desc byt_board = {


### PR DESCRIPTION
Fix host side logic for QEMU adsp. Tested with a BYT image (latest Linux driver and FW). 