### PR TITLE
x86-host: Fix qemu "-redir" deprecated warning

### DIFF
--- a/x86-host.sh
+++ b/x86-host.sh
@@ -73,7 +73,6 @@ esac
 	-device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x8 \
 	-msg timestamp=on \
 	-display sdl \
-	-netdev user,id=network0 -device e1000,netdev=network0 \
-	-redir tcp:5555::22 \
+	-netdev user,id=network0,hostfwd=tcp::5555-:22 -device e1000,netdev=network0 \
 	-monitor stdio $HDA $ADSP $2
 


### PR DESCRIPTION
Replace -redir with user,hostfwd to silence qemu's warning:
The -redir option is deprecated. Please use '-netdev user,hostfwd=...'
instead.

Signed-off-by: Dragos Tarcatu <dragos_tarcatu@mentor.com>