### PR TITLE
xtensa: adsp: xtensa-host.sh: start frozen if no kernel given

### DIFF
--- a/xtensa-host.sh
+++ b/xtensa-host.sh
@@ -77,6 +77,11 @@ while [[ $# -gt 0 ]]
 do
 key="$2"
 
+# if no kernel passed, start QEMU in frozen state
+if test x$3 == x ; then
+    DARGS="-S"
+fi
+
 case $key in
     -k|--kernel)
     KERNEL="-kernel $3"


### PR DESCRIPTION
If DSP VM is started in heterogeneous mode (no kernel given as
argument, rather the host VM will copy and start the DSP VM),
the DSP VM must be started in "non executing" mode (-S).

Modify the xtensa-host.sh script to set non-executing mode
whenever no kernel is passed to the script.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>