### PR TITLE
xtensa: adsp: xtensa-host.sh: improve args handling

### DIFF
--- a/xtensa-host.sh
+++ b/xtensa-host.sh
@@ -77,11 +77,6 @@ while [[ $# -gt 0 ]]
 do
 key="$2"
 
-# if no kernel passed, start QEMU in frozen state
-if test x$3 == x ; then
-    DARGS="-S"
-fi
-
 case $key in
     -k|--kernel)
     KERNEL="-kernel $3"
@@ -106,7 +101,8 @@ case $key in
     shift # past argument
     ;;
     -d|--debug)
-    DARGS="-s -S"
+    DARGS="-s"
+    CARGS="-S"
     shift # past argument
     ;;
     -c|--console)
@@ -127,6 +123,11 @@ case $key in
 esac
 done
 set -- "${ARG[@]}" # restore arg parameters
+
+# if no kernel passed, start QEMU in frozen state
+if [ -z $KERNEL ]; then
+    CARGS="-S"
+fi
 
 # clear old queues and memory
 rm -fr /dev/shm/qemu-bridge*


### PR DESCRIPTION
If xtensa-host.sh gets started with the GDB debugging option, but without
the kernel to load, DARGS gets overwritten to '-S' and '-s' gets lost.

Fix that by using CARGS instead of DARGS for '-S'.

Signed-off-by: Dragos Tarcatu <dragos_tarcatu@mentor.com>