### PR TITLE
xtensa: adsp: xtensa-host.sh: add quotes to string parameter

### DIFF
--- a/xtensa-host.sh
+++ b/xtensa-host.sh
@@ -125,7 +125,7 @@ done
 set -- "${ARG[@]}" # restore arg parameters
 
 # if no kernel passed, start QEMU in frozen state
-if [ -z $KERNEL ]; then
+if [ -z "$KERNEL" ]; then
     CARGS="-S"
 fi
 


### PR DESCRIPTION
Add quotes to $KERNEL to avoid the error:
"./xtensa-host.sh: line 128: [: -kernel: binary operator expected"

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>