### PR TITLE
Fix remaining issues for IRQ on cAvs DSPs

### DIFF
--- a/hw/adsp/dsp/cavs-shim.c
+++ b/hw/adsp/dsp/cavs-shim.c
@@ -39,16 +39,17 @@
 static uint64_t cavs_set_time(struct adsp_dev *adsp, struct adsp_io_info *info)
 {
 	uint64_t time = (qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) - adsp->timer[0].start);
+	uint64_t ticks = time * adsp->timer[0].clk_kHz * 1000 / ( 1000 * 1000 * 1000 );
 
-	info->region[(SHIM_DSPWC + 4) >> 2] = (uint32_t)(time >> 32);
-	info->region[(SHIM_DSPWC + 0) >> 2] = (uint32_t)(time & 0xffffffff);
+	info->region[(SHIM_DSPWC + 4) >> 2] = (uint32_t)(ticks >> 32);
+	info->region[(SHIM_DSPWC + 0) >> 2] = (uint32_t)(ticks & 0xffffffff);
 
 	return time;
 }
 
 static void rearm_ext_timer0(struct adsp_dev *adsp,struct adsp_io_info *info)
 {
-    uint64_t wake = ((uint64_t)(info->region[(SHIM_DSPWCTT0C + 4)>> 2]) << 32) | 
+    uint64_t wake = ((uint64_t)(info->region[(SHIM_DSPWCTT0C + 4)>> 2]) << 32) |
 		info->region[(SHIM_DSPWCTT0C + 0)>> 2];
 
     cavs_set_time(adsp, info);

--- a/hw/adsp/dsp/cavs.c
+++ b/hw/adsp/dsp/cavs.c
@@ -526,6 +526,7 @@ static void cavs_irq_write(void *opaque, hwaddr addr,
             info->region[ILSC(2) >> 2] =
                 (~info->region[ILMC(2) >> 2]) & info->region[ILRSD(2) >> 2];
 
+            /* clear IRQ if no other IRQ left */
             if (!info->region[ILSC(2) >> 2])
                  adsp_set_lvl1_irq(adsp, IRQ_NUM_EXT_LEVEL2, 0);
         }
@@ -538,6 +539,7 @@ static void cavs_irq_write(void *opaque, hwaddr addr,
             info->region[ILSC(3) >> 2] =
                 (~info->region[ILMC(3) >> 2]) & info->region[ILRSD(3) >> 2];
 
+            /* clear IRQ if no other IRQ left */
             if (!info->region[ILSC(3) >> 2])
                  adsp_set_lvl1_irq(adsp, IRQ_NUM_EXT_LEVEL3, 0);
         }
@@ -550,6 +552,7 @@ static void cavs_irq_write(void *opaque, hwaddr addr,
             info->region[ILSC(4) >> 2] =
                 (~info->region[ILMC(4) >> 2]) & info->region[ILRSD(4) >> 2];
 
+            /* clear IRQ if no other IRQ left */
             if (!info->region[ILSC(4) >> 2])
                  adsp_set_lvl1_irq(adsp, IRQ_NUM_EXT_LEVEL4, 0);
         }
@@ -562,6 +565,7 @@ static void cavs_irq_write(void *opaque, hwaddr addr,
             info->region[ILSC(5) >> 2] =
                 (~info->region[ILMC(5) >> 2]) & info->region[ILRSD(5) >> 2];
 
+            /* clear IRQ if no other IRQ left */
             if (!info->region[ILSC(5) >> 2])
                  adsp_set_lvl1_irq(adsp, IRQ_NUM_EXT_LEVEL5, 0);
         }
@@ -574,7 +578,8 @@ static void cavs_irq_write(void *opaque, hwaddr addr,
             info->region[ILSC(2) >> 2] =
                 (~info->region[ILMC(2) >> 2]) & info->region[ILRSD(2) >> 2];
 
-            if (!info->region[ILSC(2) >> 2])
+            /* generate an IRQ if it was masked */
+            if (info->region[ILSC(2) >> 2])
                  adsp_set_lvl1_irq(adsp, IRQ_NUM_EXT_LEVEL2, 1);
         }
         break;
@@ -586,7 +591,8 @@ static void cavs_irq_write(void *opaque, hwaddr addr,
             info->region[ILSC(3) >> 2] =
                 (~info->region[ILMC(3) >> 2]) & info->region[ILRSD(3) >> 2];
 
-            if (!info->region[ILSC(3) >> 2])
+            /* generate an IRQ if it was masked */
+            if (info->region[ILSC(3) >> 2])
                  adsp_set_lvl1_irq(adsp, IRQ_NUM_EXT_LEVEL3, 1);
         }
         break;
@@ -598,7 +604,8 @@ static void cavs_irq_write(void *opaque, hwaddr addr,
             info->region[ILSC(4) >> 2] =
                 (~info->region[ILMC(4) >> 2]) & info->region[ILRSD(4) >> 2];
 
-            if (!info->region[ILSC(4) >> 2])
+            /* generate an IRQ if it was masked */
+            if (info->region[ILSC(4) >> 2])
                  adsp_set_lvl1_irq(adsp, IRQ_NUM_EXT_LEVEL4, 1);
         }
         break;
@@ -611,7 +618,8 @@ static void cavs_irq_write(void *opaque, hwaddr addr,
             info->region[ILSC(5) >> 2] =
                 (~info->region[ILMC(5) >> 2]) & info->region[ILRSD(5) >> 2];
 
-            if (!info->region[ILSC(5) >> 2])
+            /* generate an IRQ if it was masked */
+            if (info->region[ILSC(5) >> 2])
                  adsp_set_lvl1_irq(adsp, IRQ_NUM_EXT_LEVEL5, 1);
         }
         break;

--- a/include/hw/adsp/shim.h
+++ b/include/hw/adsp/shim.h
@@ -171,10 +171,12 @@
 #define SHIM_DSPWCTT0C      0x30
 #define SHIM_DSPWCTT1C      0x38
 
-#define ILMSD(x)   (0x0 + 0x40 * (x - 2)) /* mask set - W1S */
-#define ILMCD(x)   (0x4 + 0x40 * (x - 2)) /* mask clear - W1C */
-#define ILMC(x)   (0x8 + 0x40 * (x - 2))  /* mask status - ROV */
-#define ILSC(x)   (0xc + 0x40 * (x - 2))  /* IRQ status - ROV after mask */
+/* IRQ registers for core 0 */
+#define ILMSD(x)    (0x0 + 0x10 * (x - 2)) /* mask set - W1S */
+#define ILMCD(x)   (0x4 + 0x10 * (x - 2)) /* mask clear - W1C */
+#define ILMC(x)   (0x8 + 0x10 * (x - 2))  /* mask status - ROV */
+#define ILSC(x)   (0xc + 0x10 * (x - 2))  /* IRQ status - ROV after mask */
+/* TODO: need to add macro for other cores. */
 
 #define ILRSD(x)      (0x100 + 0x4 * (x - 2))   /* RAW status */
 


### PR DESCRIPTION
1. Fix wrong IRQ macros for different LV
2. Fix wrong IRQ set after clear mask
3. Fir wrong time ticks used for timer IRQ.