### PR TITLE
ext_man: Skip extended manifest in fw loading routine

### DIFF
--- a/hw/adsp/dsp/cavs.c
+++ b/hw/adsp/dsp/cavs.c
@@ -366,7 +366,7 @@ static struct adsp_dev *adsp_init(const struct adsp_desc *board,
     struct adsp_dev *adsp;
     struct adsp_mem_desc *mem;
     void *man_ptr, *desc_ptr;
-    int n, skip = 0, size;
+    int n, skip, size;
     void *rom;
 
     adsp = g_malloc(sizeof(*adsp));
@@ -461,8 +461,10 @@ static struct adsp_dev *adsp_init(const struct adsp_desc *board,
         goto out;
     }
 
+    skip = adsp_get_ext_man_size(man_ptr);
+
     /* Search for manifest ID = "$AEM" */
-    desc_ptr = man_ptr;
+    desc_ptr = (uint8_t *)man_ptr + skip;
     while (*((uint32_t*)desc_ptr) != 0x314d4124) {
         desc_ptr = desc_ptr + sizeof(uint32_t);
         skip += sizeof(uint32_t);

--- a/include/hw/adsp/hw.h
+++ b/include/hw/adsp/hw.h
@@ -110,6 +110,7 @@ struct adsp_desc {
 	struct adsp_dev_ops *ops;
 };
 
+uint32_t adsp_get_ext_man_size(const uint32_t *fw);
 int adsp_load_modules(struct adsp_dev *adsp, void *fw, size_t size);
 
 struct adsp_dev;


### PR DESCRIPTION
There is no need to parse extended manifest in quemu at this moment,
so it should be skipped to allow successfully fw load.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>