### PR TITLE
Bugfix for SDMA

### DIFF
--- a/hw/adsp/dsp/imx8m.c
+++ b/hw/adsp/dsp/imx8m.c
@@ -209,7 +209,7 @@ static struct adsp_reg_space imx8m_io[] = {
         .reg = adsp_sdma_map,
         .init = &sdma_init_dev, .ops = &sdma_ops,
         .desc = {.base = ADSP_IMX8M_DSP_SDMA_BASE,
-        .size = ADSP_IMX8M_DSP_SDMA_BASE},},
+        .size = ADSP_IMX8M_DSP_SDMA_SIZE},},
 };
 
 /* hardware memory map */


### PR DESCRIPTION
Fix SDMA size in IO space for i.MX8M. i.MX8M boots now.

Signed-off-by: Diana Cretu <dianacretu2806@gmail.com>