### PR TITLE
Add shebangs

### DIFF
--- a/x86-host.sh
+++ b/x86-host.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [ $# -eq 0 ]
 then
   echo "usage: $0 device kernel fs_image.ext4"

--- a/x86-modcpy.sh
+++ b/x86-modcpy.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # script to copy kernel modules to Poky FS for Qemu
 # Needs to run under sudo for mount and copy to FS
 

--- a/xtensa-host.sh
+++ b/xtensa-host.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 set -e
 

--- a/xtensa-trace.sh
+++ b/xtensa-trace.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Simple script to trace execution. Can be vastly improved upon.
 #
 # Usage.


### PR DESCRIPTION
Executable scripts need a shebang to find an interpreter to run the
script with. These scripts do not have a shebang and would need to be
used as 'bash xtensa-trace.sh' (if executing with any other shell).
However, most of the docs and generally people would execute it as
'./xtensa-trace.sh' which needs shebangs.

Signed-off-by: Shreeya Patel <shreeya.patel23498@gmail.com>