### PR TITLE
qemu: io-bridge: remove fd assignment after its closed

### DIFF
--- a/util/qemu-io-bridge.c
+++ b/util/qemu-io-bridge.c
@@ -391,6 +391,5 @@ void qemu_io_free_shm(int region)
         /* client or host can unlink this, so it gets done twice */
         shm_unlink(_iob.shm[region].name);
         close(_iob.shm[region].fd);
-        _iob.shm[region].fd = 0;
     }
 }


### PR DESCRIPTION
The free descriptor is closed using close system call and in the
next step it is assigned again to 0. Remove this assignment.

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>