### PR TITLE
xtensa-host.sh: log the full command including the timeout prefix

### DIFF
--- a/xtensa-host.sh
+++ b/xtensa-host.sh
@@ -197,7 +197,7 @@ rm -fr /dev/mqueue/qemu-io-*
 #    (gdb)
 #
 
-echo "${MY_DIR}"/xtensa-softmmu/qemu-system-xtensa -cpu $CPU -M $ADSP $TARGS $DARGS $IARGS -nographic $KERNEL $ROM $CARGS $GARGS \> "$LOG"
+set -x
 if [ -z ${TIMEOUT} ]; then
 	"${MY_DIR}"/xtensa-softmmu/qemu-system-xtensa -cpu $CPU -M $ADSP $TARGS $DARGS $IARGS -nographic $KERNEL $ROM $CARGS $GARGS -semihosting;
 else


### PR DESCRIPTION
Replace the custom and incomplete command logging with a simpler set -x.

../sof/qemu-check.sh and maybe others invoke this script with a non-zero
${TIMEOUT} to stop qemu. This prints the following line every time; even
in successful cases which can be confusing
  `qemu-system-xtensa: terminating on signal 15 from pid 9823 (timeout)`

Logging the timeout prefix reduces this confusion

Signed-off-by: Marc Herbert <marc.herbert@intel.com>